### PR TITLE
feat(schedule): grouped view, badges, project colors, and UX tweaks

### DIFF
--- a/frontend/public/schedule.json
+++ b/frontend/public/schedule.json
@@ -1,36 +1,68 @@
 [
   { "week": 1, "date": "8/19/2025", "lectureTopic": "Introduction", "readingTopic": "no reading", "materials": [] },
-  { "week": 1, "date": "8/21/2025", "lectureTopic": "My research / how to read papers", "readingTopic": "no reading", "materials": [] },
-  { "week": 2, "date": "8/26/2025", "lectureTopic": "Intro to social media", "readingTopic": "dataset & data collection", "materials": [] },
-  { "week": 2, "date": "8/28/2025", "lectureTopic": "Intro to social media", "readingTopic": "dataset & data collection", "materials": [] },
-  { "week": 3, "date": "9/2/2025", "lectureTopic": "Data collection", "readingTopic": "dataset & data collection", "materials": [] },
-  { "week": 3, "date": "9/4/2025", "lectureTopic": "Data collection", "readingTopic": "dataset & data collection", "materials": [] },
-  { "week": 4, "date": "9/9/2025", "lectureTopic": "Data collection", "readingTopic": "dataset & data collection", "materials": [] },
-  { "week": 4, "date": "9/11/2025", "lectureTopic": "Git and CLI crash course", "readingTopic": "algorithmic bias", "materials": [] },
-  { "week": 5, "date": "9/16/2025", "lectureTopic": "Discussing the proposal", "readingTopic": "algorithmic bias", "materials": [] },
-  { "week": 5, "date": "9/18/2025", "lectureTopic": "Data format JSON & CSV", "readingTopic": "algorithmic bias", "materials": [] },
+  { "week": 1, "date": "8/21/2025", "lectureTopic": "How to read papers", "readingTopic": "no reading", "materials": [
+    { "title": "CoVaxxy: A Collection of English-Language Twitter Posts About COVID-19 Vaccines", "url": "https://ojs.aaai.org/index.php/ICWSM/article/view/18122" }
+  ] },
+  { "week": 2, "date": "8/26/2025", "lectureTopic": "Intro to social media", "readingTopic": "Dataset & data collection", "materials": [
+    { "title": "A Multi-Platform Collection of Social Media Posts about the 2022 U.S. Midterm Elections", "url": "https://ojs.aaai.org/index.php/ICWSM/article/view/22205" }
+  ] },
+  { "week": 2, "date": "8/28/2025", "lectureTopic": "Intro to social media", "readingTopic": "Dataset & data collection", "materials": [
+    { "title": "Raiders of the Lost Kek: 3.5 Years ofAugmented 4chan Posts from the Politically Incorrect Board", "url": "https://doi.org/10.1609/icwsm.v14i1.7354" }
+  ] },
+  { "week": 3, "date": "9/2/2025", "lectureTopic": "Data collection", "readingTopic": "Dataset & data collection", "materials": [], "project": {
+    "project number": "1",
+    "event": "release"
+  } },
+  { "week": 3, "date": "9/4/2025", "lectureTopic": "Data collection", "readingTopic": "Dataset & data collection", "materials": [] },
+  { "week": 4, "date": "9/9/2025", "lectureTopic": "Data collection", "readingTopic": "Dataset & data collection", "materials": [] },
+  { "week": 4, "date": "9/11/2025", "lectureTopic": "Git and CLI crash course", "readingTopic": "Algorithmic bias", "materials": [] },
+  { "week": 5, "date": "9/16/2025", "lectureTopic": "Data format JSON & CSV", "readingTopic": "Algorithmic bias", "materials": [], "project": {
+    "project number": "1",
+    "event": "proposal deadline"
+  } },
+  { "week": 5, "date": "9/18/2025", "lectureTopic": "Discussing P1 proposal", "readingTopic": "Algorithmic bias", "materials": [] },
   { "week": 6, "date": "9/23/2025", "lectureTopic": "No class (Rosh Hashanah)", "readingTopic": "no reading", "materials": [] },
-  { "week": 6, "date": "9/25/2025", "lectureTopic": "Data format JSON & CSV", "readingTopic": "algorithmic bias", "materials": [] },
-  { "week": 7, "date": "9/30/2025", "lectureTopic": "Data format JSON & CSV", "readingTopic": "algorithmic bias", "materials": [] },
+  { "week": 6, "date": "9/25/2025", "lectureTopic": "Data format JSON & CSV", "readingTopic": "Algorithmic bias", "materials": [] },
+  { "week": 7, "date": "9/30/2025", "lectureTopic": "Data format JSON & CSV", "readingTopic": "Algorithmic bias", "materials": [] },
   { "week": 7, "date": "10/2/2025", "lectureTopic": "No class (Yom Kippur)", "readingTopic": "no reading", "materials": [] },
-  { "week": 8, "date": "10/7/2025", "lectureTopic": "Database SQL & NoSQL", "readingTopic": "algorithmic bias", "materials": [] },
-  { "week": 8, "date": "10/9/2025", "lectureTopic": "Discussing the P1 imp & report", "readingTopic": "inauthentic behaviors", "materials": [] },
-  { "week": 9, "date": "10/14/2025", "lectureTopic": "Database SQL & NoSQL", "readingTopic": "inauthentic behaviors", "materials": [] },
-  { "week": 9, "date": "10/16/2025", "lectureTopic": "Database SQL & NoSQL", "readingTopic": "inauthentic behaviors", "materials": [] },
-  { "week": 10, "date": "10/21/2025", "lectureTopic": "Discussing the P2 proposal", "readingTopic": "inauthentic behaviors", "materials": [] },
-  { "week": 10, "date": "10/23/2025", "lectureTopic": "Stats basics", "readingTopic": "inauthentic behaviors", "materials": [] },
-  { "week": 11, "date": "10/28/2025", "lectureTopic": "Stats basics", "readingTopic": "ethics and data access", "materials": [] },
-  { "week": 11, "date": "10/30/2025", "lectureTopic": "Stats basics", "readingTopic": "ethics and data access", "materials": [] },
-  { "week": 12, "date": "11/4/2025", "lectureTopic": "Data wrangling & vis", "readingTopic": "ethics and data access", "materials": [] },
-  { "week": 12, "date": "11/6/2025", "lectureTopic": "Data wrangling & vis", "readingTopic": "ethics and data access", "materials": [] },
-  { "week": 13, "date": "11/11/2025", "lectureTopic": "Data wrangling & vis", "readingTopic": "ethics and data access", "materials": [] },
-  { "week": 13, "date": "11/13/2025", "lectureTopic": "Discussing the P2 imp & report", "readingTopic": "generative AI and social media", "materials": [] },
-  { "week": 14, "date": "11/18/2025", "lectureTopic": "Data wrangling & vis", "readingTopic": "generative AI and social media", "materials": [] },
-  { "week": 14, "date": "11/20/2025", "lectureTopic": "Left for flexibility", "readingTopic": "generative AI and social media", "materials": [] },
-  { "week": 15, "date": "11/25/2025", "lectureTopic": "Discussing the P3 proposal", "readingTopic": "generative AI and social media", "materials": [] },
+  { "week": 8, "date": "10/7/2025", "lectureTopic": "Database SQL & NoSQL", "readingTopic": "Algorithmic bias", "materials": [], "project": {
+    "project number": "2",
+    "event": "release"
+  } },
+  { "week": 8, "date": "10/9/2025", "lectureTopic": "Database SQL & NoSQL", "readingTopic": "Inauthentic behaviors", "materials": [], "project": {
+    "project number": "1",
+    "event": "implementation & report deadline"
+  } },
+  { "week": 9, "date": "10/14/2025", "lectureTopic": "Discussing P1 implementation & report", "readingTopic": "Inauthentic behaviors", "materials": [] },
+  { "week": 9, "date": "10/16/2025", "lectureTopic": "Database SQL & NoSQL", "readingTopic": "Inauthentic behaviors", "materials": [] },
+  { "week": 10, "date": "10/21/2025", "lectureTopic": "Stats basics", "readingTopic": "Inauthentic behaviors", "materials": [], "project": {
+    "project number": "2",
+    "event": "proposal deadline"
+  } },
+  { "week": 10, "date": "10/23/2025", "lectureTopic": "Discussing P2 proposal", "readingTopic": "Inauthentic behaviors", "materials": [] },
+  { "week": 11, "date": "10/28/2025", "lectureTopic": "Stats basics", "readingTopic": "Ethics and data access", "materials": [] },
+  { "week": 11, "date": "10/30/2025", "lectureTopic": "Data wrangling & vis", "readingTopic": "Ethics and data access", "materials": [] },
+  { "week": 12, "date": "11/4/2025", "lectureTopic": "Data wrangling & vis", "readingTopic": "Ethics and data access", "materials": [] },
+  { "week": 12, "date": "11/6/2025", "lectureTopic": "Data wrangling & vis", "readingTopic": "Ethics and data access", "materials": [], "project": {
+    "project number": "3",
+    "event": "release"
+  }  },
+  { "week": 13, "date": "11/11/2025", "lectureTopic": "Data wrangling & vis", "readingTopic": "Ethics and data access", "materials": []},
+  { "week": 13, "date": "11/13/2025", "lectureTopic": "Data wrangling & vis", "readingTopic": "Generative AI and social media", "materials": [], "project": {
+    "project number": "2",
+    "event": "implementation & report deadline"
+  } },
+  { "week": 14, "date": "11/18/2025", "lectureTopic": "Discussing P2 implementation & report", "readingTopic": "Generative AI and social media", "materials": [] },
+  { "week": 14, "date": "11/20/2025", "lectureTopic": "", "readingTopic": "Generative AI and social media", "materials": [], "project": {
+    "project number": "3",
+    "event": "proposal deadline"
+  } },
+  { "week": 15, "date": "11/25/2025", "lectureTopic": "Discussing the P3 proposal", "readingTopic": "Generative AI and social media", "materials": []},
   { "week": 15, "date": "11/27/2025", "lectureTopic": "No class (Thanks giving break)", "readingTopic": "no reading", "materials": [] },
-  { "week": 16, "date": "12/2/2025", "lectureTopic": "Left for flexibility", "readingTopic": "generative AI and social media", "materials": [] },
-  { "week": 16, "date": "12/4/2025", "lectureTopic": "Left for flexibility", "readingTopic": "generative AI and social media", "materials": [] },
-  { "week": 17, "date": "12/12/2025", "lectureTopic": "Fianl examination week", "readingTopic": "", "materials": [] }
+  { "week": 16, "date": "12/2/2025", "lectureTopic": "", "readingTopic": "Generative AI and social media", "materials": [] },
+  { "week": 16, "date": "12/4/2025", "lectureTopic": "", "readingTopic": "Generative AI and social media", "materials": [], "project": {
+    "project number": "3",
+    "event": "implementation & report deadline"
+  } },
+  { "week": 17, "date": "12/12/2025", "lectureTopic": "Final examination week", "readingTopic": "no reading", "materials": [] }
 ]
-

--- a/frontend/src/pages/Schedule.vue
+++ b/frontend/src/pages/Schedule.vue
@@ -28,12 +28,20 @@ const isNoClass = (topic) => /^\s*No class/i.test(topic || '')
 const lectureRemainder = (topic) => (topic || '').replace(/^\s*No class\s*/i, '').trim()
 const isNoReading = (topic) => /^no\s*reading$/i.test((topic || '').trim())
 const isEmpty = (s) => !(s && String(s).trim())
-// Compose a project badge label from schedule.json fields
+// Compose a project badge label from schedule.json fields (robust to key names)
 const projectLabel = (row) => {
-  const num = row?.['project number'] ?? row?.projectNumber ?? row?.project_number
-  const ev = (row?.event ?? row?.projectEvent ?? row?.project_event) || ''
+  if (!row || typeof row !== 'object') return ''
+  const entries = Object.entries(row)
+  if (row.project && typeof row.project === 'object') {
+    entries.push(...Object.entries(row.project))
+  }
+  const norm = (k) => String(k).toLowerCase().replace(/[\s_-]+/g, '')
+  const map = new Map(entries.map(([k, v]) => [norm(k), v]))
+
+  const num = map.get('projectnumber') ?? map.get('projectno') ?? map.get('p') ?? map.get('pnum')
+  const ev = map.get('event') ?? map.get('projectevent') ?? map.get('milestone') ?? ''
   const n = (num !== undefined && num !== null && String(num).trim() !== '') ? String(num).trim() : ''
-  const e = String(ev).trim()
+  const e = String(ev || '').trim()
   if (!n && !e) return ''
   if (n && e) return `P${n}: ${e}`
   return n ? `P${n}` : e

--- a/frontend/src/pages/Schedule.vue
+++ b/frontend/src/pages/Schedule.vue
@@ -90,7 +90,8 @@ const isPast = (row) => {
 <template>
   <main class="container pb-5">
     <h1 class="h3 my-4">Schedule</h1>
-    <p class="text-muted">The schedule is subject to change, so please check it regularly for updates.</p>
+    <p>The schedule will be adjusted as we go, so please check it regularly for updates.</p>
+    <p>Note: Reading assignments should be completed before class. There may be a quiz on the reading material, and students are expected to participate in class discussions about the papers.</p>
 
     <div class="table-responsive">
       <table class="table table-striped table-hover align-middle">

--- a/frontend/src/pages/Schedule.vue
+++ b/frontend/src/pages/Schedule.vue
@@ -23,6 +23,10 @@ const weekGroups = computed(() => {
   }
   return Array.from(map.entries()).map(([week, items]) => ({ week, items }))
 })
+
+const isNoClass = (topic) => /^\s*No class/i.test(topic || '')
+const lectureRemainder = (topic) => (topic || '').replace(/^\s*No class\s*/i, '').trim()
+const isNoReading = (topic) => /^no\s*reading$/i.test((topic || '').trim())
 </script>
 
 <template>
@@ -47,12 +51,21 @@ const weekGroups = computed(() => {
           <tr v-for="row in group.items" :key="row.week + '-' + row.date">
             <td style="white-space:nowrap">{{ row.date }}</td>
             <td>
-              <span v-if="/^\s*No class/i.test(row.lectureTopic)" class="badge text-bg-secondary me-2">No class</span>
-              {{ row.lectureTopic }}
+              <template v-if="isNoClass(row.lectureTopic)">
+                <span class="badge text-bg-secondary me-2">No class</span>
+                <span v-if="lectureRemainder(row.lectureTopic)">{{ lectureRemainder(row.lectureTopic) }}</span>
+              </template>
+              <template v-else>
+                {{ row.lectureTopic }}
+              </template>
             </td>
             <td>
-              <span v-if="/^no\s*reading$/i.test(row.readingTopic || '')" class="badge text-bg-secondary me-2">No reading</span>
-              {{ row.readingTopic }}
+              <template v-if="isNoReading(row.readingTopic)">
+                <span class="badge text-bg-secondary">No reading</span>
+              </template>
+              <template v-else>
+                {{ row.readingTopic }}
+              </template>
             </td>
             <td>
               <template v-if="row.materials && row.materials.length">

--- a/frontend/src/pages/Schedule.vue
+++ b/frontend/src/pages/Schedule.vue
@@ -76,8 +76,8 @@ const isNoReading = (topic) => /^no\s*reading$/i.test((topic || '').trim())
                 </ul>
               </template>
               <template v-else>
-                <span v-if="/^no\s*reading$/i.test(row.readingTopic || '')" class="badge text-bg-secondary">No reading</span>
-                <span v-else class="badge text-bg-warning">TBD</span>
+                <!-- Leave empty when there is no reading that day; otherwise show TBD -->
+                <span v-if="!isNoReading(row.readingTopic)" class="badge text-bg-warning">TBD</span>
               </template>
             </td>
           </tr>

--- a/frontend/src/pages/Schedule.vue
+++ b/frontend/src/pages/Schedule.vue
@@ -27,6 +27,7 @@ const weekGroups = computed(() => {
 const isNoClass = (topic) => /^\s*No class/i.test(topic || '')
 const lectureRemainder = (topic) => (topic || '').replace(/^\s*No class\s*/i, '').trim()
 const isNoReading = (topic) => /^no\s*reading$/i.test((topic || '').trim())
+const isEmpty = (s) => !(s && String(s).trim())
 </script>
 
 <template>
@@ -55,6 +56,9 @@ const isNoReading = (topic) => /^no\s*reading$/i.test((topic || '').trim())
               <template v-if="isNoClass(row.lectureTopic)">
                 <span class="badge text-bg-secondary me-2">No class</span>
                 <span v-if="lectureRemainder(row.lectureTopic)">{{ lectureRemainder(row.lectureTopic) }}</span>
+              </template>
+              <template v-else-if="isEmpty(row.lectureTopic)">
+                <span class="badge text-bg-warning">TBD</span>
               </template>
               <template v-else>
                 {{ row.lectureTopic }}

--- a/frontend/src/pages/Schedule.vue
+++ b/frontend/src/pages/Schedule.vue
@@ -34,7 +34,6 @@ const weekGroups = computed(() => {
       <table class="table table-striped table-hover align-middle">
         <thead class="table-light">
           <tr>
-            <th scope="col" style="white-space:nowrap">Week</th>
             <th scope="col" style="white-space:nowrap">Date</th>
             <th scope="col">Lecture Topic</th>
             <th scope="col">Reading Topic</th>
@@ -43,10 +42,9 @@ const weekGroups = computed(() => {
         </thead>
         <tbody v-for="group in weekGroups" :key="'w'+group.week">
           <tr class="table-secondary week-header">
-            <th colspan="5">Week {{ group.week }}</th>
+            <th colspan="4">Week {{ group.week }}</th>
           </tr>
           <tr v-for="row in group.items" :key="row.week + '-' + row.date">
-            <td class="text-muted" style="white-space:nowrap">{{ row.week }}</td>
             <td style="white-space:nowrap">{{ row.date }}</td>
             <td>
               <span v-if="/^\s*No class/i.test(row.lectureTopic)" class="badge text-bg-secondary me-2">No class</span>

--- a/frontend/src/pages/Schedule.vue
+++ b/frontend/src/pages/Schedule.vue
@@ -28,6 +28,16 @@ const isNoClass = (topic) => /^\s*No class/i.test(topic || '')
 const lectureRemainder = (topic) => (topic || '').replace(/^\s*No class\s*/i, '').trim()
 const isNoReading = (topic) => /^no\s*reading$/i.test((topic || '').trim())
 const isEmpty = (s) => !(s && String(s).trim())
+// Compose a project badge label from schedule.json fields
+const projectLabel = (row) => {
+  const num = row?.['project number'] ?? row?.projectNumber ?? row?.project_number
+  const ev = (row?.event ?? row?.projectEvent ?? row?.project_event) || ''
+  const n = (num !== undefined && num !== null && String(num).trim() !== '') ? String(num).trim() : ''
+  const e = String(ev).trim()
+  if (!n && !e) return ''
+  if (n && e) return `P${n}: ${e}`
+  return n ? `P${n}` : e
+}
 
 // Utilities to detect past dates (relative to local today)
 const parseMDY = (mdy) => {
@@ -109,8 +119,8 @@ const isPast = (row) => {
               </template>
             </td>
             <td>
-              <template v-if="row.project">
-                <span class="badge text-bg-info">{{ row.project }}</span>
+              <template v-if="projectLabel(row)">
+                <span class="badge text-bg-info">{{ projectLabel(row) }}</span>
               </template>
             </td>
           </tr>

--- a/frontend/src/pages/Schedule.vue
+++ b/frontend/src/pages/Schedule.vue
@@ -41,8 +41,8 @@ const isNoReading = (topic) => /^no\s*reading$/i.test((topic || '').trim())
             <th scope="col" style="white-space:nowrap">Date</th>
             <th scope="col">Lecture Topic</th>
             <th scope="col">Reading Topic</th>
-            <th scope="col" style="white-space:nowrap">Projects</th>
             <th scope="col" style="min-width:220px">Reading Materials</th>
+            <th scope="col" style="white-space:nowrap">Projects</th>
           </tr>
         </thead>
         <tbody v-for="group in weekGroups" :key="'w'+group.week">
@@ -69,11 +69,6 @@ const isNoReading = (topic) => /^no\s*reading$/i.test((topic || '').trim())
               </template>
             </td>
             <td>
-              <template v-if="row.project">
-                <span class="badge text-bg-info">{{ row.project }}</span>
-              </template>
-            </td>
-            <td>
               <template v-if="row.materials && row.materials.length">
                 <ul class="mb-0 ps-3">
                   <li v-for="m in row.materials" :key="m.title">
@@ -84,6 +79,11 @@ const isNoReading = (topic) => /^no\s*reading$/i.test((topic || '').trim())
               <template v-else>
                 <!-- Leave empty when there is no reading that day; otherwise show TBD -->
                 <span v-if="!isNoReading(row.readingTopic)" class="badge text-bg-warning">TBD</span>
+              </template>
+            </td>
+            <td>
+              <template v-if="row.project">
+                <span class="badge text-bg-info">{{ row.project }}</span>
               </template>
             </td>
           </tr>

--- a/frontend/src/pages/Schedule.vue
+++ b/frontend/src/pages/Schedule.vue
@@ -41,12 +41,13 @@ const isNoReading = (topic) => /^no\s*reading$/i.test((topic || '').trim())
             <th scope="col" style="white-space:nowrap">Date</th>
             <th scope="col">Lecture Topic</th>
             <th scope="col">Reading Topic</th>
+            <th scope="col" style="white-space:nowrap">Projects</th>
             <th scope="col" style="min-width:220px">Reading Materials</th>
           </tr>
         </thead>
         <tbody v-for="group in weekGroups" :key="'w'+group.week">
           <tr class="table-secondary week-header">
-            <th colspan="4">Week {{ group.week }}</th>
+            <th colspan="5">Week {{ group.week }}</th>
           </tr>
           <tr v-for="row in group.items" :key="row.week + '-' + row.date">
             <td style="white-space:nowrap">{{ row.date }}</td>
@@ -65,6 +66,11 @@ const isNoReading = (topic) => /^no\s*reading$/i.test((topic || '').trim())
               </template>
               <template v-else>
                 {{ row.readingTopic }}
+              </template>
+            </td>
+            <td>
+              <template v-if="row.project">
+                <span class="badge text-bg-info">{{ row.project }}</span>
               </template>
             </td>
             <td>

--- a/frontend/src/pages/Schedule.vue
+++ b/frontend/src/pages/Schedule.vue
@@ -47,6 +47,26 @@ const projectLabel = (row) => {
   return n ? `P${n}` : e
 }
 
+// Determine badge color based on project number
+const projectBadgeClass = (row) => {
+  if (!row || typeof row !== 'object') return 'text-bg-info'
+  const entries = Object.entries(row)
+  if (row.project && typeof row.project === 'object') {
+    entries.push(...Object.entries(row.project))
+  }
+  const norm = (k) => String(k).toLowerCase().replace(/[\s_-]+/g, '')
+  const map = new Map(entries.map(([k, v]) => [norm(k), v]))
+  const numRaw = map.get('projectnumber') ?? map.get('projectno') ?? map.get('p') ?? map.get('pnum')
+  const n = String(numRaw ?? '').trim()
+  switch (n) {
+    case '1': return 'text-bg-primary'
+    case '2': return 'text-bg-success'
+    case '3': return 'text-bg-warning'
+    case '4': return 'text-bg-danger'
+    default: return 'text-bg-info'
+  }
+}
+
 // Utilities to detect past dates (relative to local today)
 const parseMDY = (mdy) => {
   if (!mdy) return null
@@ -128,7 +148,7 @@ const isPast = (row) => {
             </td>
             <td>
               <template v-if="projectLabel(row)">
-                <span class="badge text-bg-info">{{ projectLabel(row) }}</span>
+                <span class="badge" :class="projectBadgeClass(row)">{{ projectLabel(row) }}</span>
               </template>
             </td>
           </tr>

--- a/frontend/src/pages/Schedule.vue
+++ b/frontend/src/pages/Schedule.vue
@@ -28,6 +28,25 @@ const isNoClass = (topic) => /^\s*No class/i.test(topic || '')
 const lectureRemainder = (topic) => (topic || '').replace(/^\s*No class\s*/i, '').trim()
 const isNoReading = (topic) => /^no\s*reading$/i.test((topic || '').trim())
 const isEmpty = (s) => !(s && String(s).trim())
+
+// Utilities to detect past dates (relative to local today)
+const parseMDY = (mdy) => {
+  if (!mdy) return null
+  const parts = String(mdy).split('/')
+  if (parts.length !== 3) return null
+  const [m, d, y] = parts.map((p) => Number(p))
+  if (!m || !d || !y) return null
+  return new Date(y, m - 1, d)
+}
+const startOfToday = () => {
+  const t = new Date()
+  return new Date(t.getFullYear(), t.getMonth(), t.getDate())
+}
+const isPast = (row) => {
+  const dt = parseMDY(row?.date)
+  if (!dt) return false
+  return dt < startOfToday()
+}
 </script>
 
 <template>
@@ -50,7 +69,11 @@ const isEmpty = (s) => !(s && String(s).trim())
           <tr class="table-secondary week-header">
             <th colspan="5">Week {{ group.week }}</th>
           </tr>
-          <tr v-for="row in group.items" :key="row.week + '-' + row.date">
+          <tr
+            v-for="row in group.items"
+            :key="row.week + '-' + row.date"
+            :class="{ 'past-row': isPast(row) || isNoClass(row.lectureTopic) }"
+          >
             <td style="white-space:nowrap">{{ row.date }}</td>
             <td>
               <template v-if="isNoClass(row.lectureTopic)">
@@ -103,5 +126,12 @@ td, th {
 }
 .week-header th {
   font-weight: 600;
+}
+.past-row {
+  opacity: 0.7;
+}
+.past-row td,
+.past-row th {
+  color: #6c757d; /* Bootstrap gray-600 */
 }
 </style>


### PR DESCRIPTION
This PR improves the Schedule page UI and data rendering.

Highlights
- Group rows by week with headers
- Badges: “No class”, “No reading”, and “TBD” (when lecture topic empty)
- Past and no-class rows shown in muted gray style
- Columns: Date, Lecture Topic, Reading Topic, Reading Materials, Projects
- Projects: color-coded badge (P1 blue, P2 green, P3 yellow, P4 red)
- Read project metadata from nested  object (e.g., {"project number": "1", "event": "implementation & report deadline"})
- Reading Materials left empty on "no reading" days; otherwise "TBD" if not provided

Data
- Uses  at runtime (no CSV)

Copy
- Updated intro notes/reading expectations on the schedule page.

Merging will redeploy via GitHub Pages workflow.