### PR TITLE
Add Missing Semester and LaTeX resources to course website

### DIFF
--- a/frontend/public/resources.json
+++ b/frontend/public/resources.json
@@ -84,6 +84,17 @@
       ]
     },
     {
+      "title": "Missing Semester",
+      "description": "Useful resources crucial for CS students but not covered in the curriculum",
+      "resources": [
+        {
+          "title": "Missing Semester",
+          "description": "A collection of lectures on various CS tools and concepts",
+          "href": "https://missing.csail.mit.edu/"
+        }
+      ]
+    },
+    {
       "title": "LaTeX",
       "description": "Useful tools for writing LaTeX documents",
       "resources": [

--- a/frontend/public/resources.json
+++ b/frontend/public/resources.json
@@ -82,6 +82,30 @@
           "href": "https://gephi.org/"
         }
       ]
+    },
+    {
+      "title": "LaTeX",
+      "description": "Useful tools for writing LaTeX documents",
+      "resources": [
+        {
+          "title": "LaTeX distributions",
+          "description": "Find the LaTeX distribution that best suits your OS",
+          "href": "https://www.latex-project.org/get/"
+        },
+        {
+          "title": "Overleaf",
+          "description": "Online LaTeX editor",
+          "href": "https://www.overleaf.com/"
+        },
+        {
+          "title": "ACM LaTeX template official website",
+          "href": "https://www.acm.org/publications/proceedings-template"
+        },
+        {
+          "title": "ACM LaTeX template on Overleaf",
+          "href": "https://www.overleaf.com/latex/templates/acm-conference-proceedings-primary-article-template/wbvnghjbzwpc"
+        }
+      ]
     }
   ]
 }


### PR DESCRIPTION
## Summary
- Add Missing Semester section with MIT's essential CS tools and concepts course
- Add comprehensive LaTeX resources section with distributions and templates
- Enhance course resources page with academic writing and development tools

## New Resource Sections
- **Missing Semester**: MIT course covering essential CS tools not typically taught in curriculum
- **LaTeX Tools**: LaTeX distributions, Overleaf online editor, and ACM conference paper templates

## Test plan
- [x] Verify Missing Semester and LaTeX sections display correctly on resources page
- [x] Confirm all resource links are functional and lead to correct destinations
- [x] Test course website renders new sections with proper formatting

🤖 Generated with [Claude Code](https://claude.ai/code)